### PR TITLE
Fixed broken links so project actually builds now

### DIFF
--- a/xmlimplsrc/build.xml
+++ b/xmlimplsrc/build.xml
@@ -11,8 +11,7 @@
     no-xmlbeans: Will cause the old, XMLBeans-based implementation of E4X not to be built
   -->
 
-  <property file="build.local.properties"/>
-  <property file="build.properties"/>
+  <property file="build.properties" />
 
   <!--
     Provide support for the old name for skipping E4X compilation, in case someone is still using it
@@ -22,8 +21,8 @@
   </condition>
 
   <path id="xmlbeans.classpath">
-    <pathelement location="${xbean.jar}"/>
-    <pathelement location="${jsr173.jar}"/>
+    <pathelement location="${xbean.jar}" />
+    <pathelement location="${jsr173.jar}" />
   </path>
 
   <target name="compile" unless="no-e4x">
@@ -37,14 +36,14 @@
 
   <target name="e4x-compile" if="jdk1.5?">
     <javac
-      srcdir="xmlimplsrc"
-      destdir="${classes}"
-      deprecation="on"
-      debug="${debug}"
-                        includeAntRuntime="false"
-      target="${target-jvm}"
-      source="${source-level}"
-    />
+            srcdir="xmlimplsrc"
+            destdir="${classes}"
+            deprecation="on"
+            debug="${debug}"
+            includeAntRuntime="false"
+            target="${target-jvm}"
+            source="${source-level}"
+            />
   </target>
 
   <target name="no-e4x-compile" unless="jdk1.5?">
@@ -63,7 +62,7 @@
     <antcall target="no-old-e4x-compile" />
   </target>
 
-  <target name="old-e4x-compile" depends="xmlbeans-unzip">
+  <target name="old-e4x-compile" depends="xmlbeans-get">
     <echo>Compiling XMLBeans E4X implementation using ${xbean.jar} and ${jsr173.jar}</echo>
     <javac srcdir="deprecatedsrc"
            destdir="${classes}"
@@ -86,22 +85,15 @@
   <target name="copy-source">
     <mkdir dir="${dist.dir}/xmlimplsrc"/>
     <copy todir="${dist.dir}/xmlimplsrc">
-      <fileset dir="xmlimplsrc"
-               includes="**/*.java,**/*.properties,**/*.xml"
-      />
+      <fileset dir="xmlimplsrc" includes="**/*.java,**/*.properties,**/*.xml" />
     </copy>
   </target>
 
   <target name="clean">
     <delete includeEmptyDirs="true">
-      <fileset dir="${classes}"
-               includes="org/mozilla/javascript/xmlimpl/**"
-      />
+      <fileset dir="${classes}" includes="org/mozilla/javascript/xmlimpl/**" />
     </delete>
   </target>
-
-  <property name="xmlbeans.tmp" location="${build.dir}/tmp-xbean" />
-  <property name="xmlbeans.zip" location="${xmlbeans.tmp}/xbean.zip" />
 
   <condition property="xmlbeans-present?">
     <and>
@@ -110,25 +102,11 @@
     </and>
   </condition>
 
-  <condition property="xmlbeans-zip-present?">
-    <available file="${xmlbeans.zip}" />
-  </condition>
-
-  <target name="xmlbeans-get" unless="xmlbeans-zip-present?">
-    <property
-      name="xmlbeans.url"
-      value="http://www.apache.org/dist/xmlbeans/binaries/xmlbeans-2.5.0.zip"
-    />
-
-    <mkdir dir="${xmlbeans.tmp}" />
-    <get src="${xmlbeans.url}" dest="${xmlbeans.zip}" ignoreerrors="true" />
-  </target>
-
-  <target name="xmlbeans-unzip" unless="xmlbeans-present?">
-    <antcall target="xmlbeans-get" />
-    <unzip src="${xmlbeans.zip}" dest="${xmlbeans.tmp}" />
-    <copy tofile="${xbean.jar}" file="${xmlbeans.tmp}/xmlbeans-2.5.0/lib/xbean.jar" />
-    <copy tofile="${jsr173.jar}" file="${xmlbeans.tmp}/xmlbeans-2.5.0/lib/jsr173_1.0_api.jar" />
-    <delete dir="${xmlbeans.tmp}" />
-  </target>
+    <target name="xmlbeans-get" unless="xmlbeans-present?">
+        <property name="xmlbeans.url" value="http://central.maven.org/maven2/org/apache/xmlbeans/xmlbeans/2.6.0/xmlbeans-2.6.0.jar" />
+        <property name="jsr173.url" value="http://central.maven.org/maven2/javax/xml/jsr173/1.0/jsr173-1.0.jar" />
+        <mkdir dir="${xmlbeans}/lib/" />
+        <get src="${xmlbeans.url}" dest="${xmlbeans}/lib/" ignoreerrors="false" />
+        <get src="${jsr173.url}" dest="${xmlbeans}/lib/" ignoreerrors="true" />
+    </target>
 </project>


### PR DESCRIPTION
The old URLs have been removed from apache. I was able to find the proper jar files in mvnrepository.com
- [jsr173.jar](http://mvnrepository.com/artifact/javax.xml/jsr173/1.0)
- [xbeans.jar](http://mvnrepository.com/artifact/org.apache.xmlbeans/xmlbeans/2.6.0)

Made changes to `xmlimplsrc/build.xml` so the project builds again with ant 1.9.5 and java 1.7.0_51.

**Update:** also builds properly with java 1.8.0_45
